### PR TITLE
Py3.6+ updates

### DIFF
--- a/lib/fdiff/__init__.py
+++ b/lib/fdiff/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 version = __version__ = "0.4.0.dev0"

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import os
 import sys
@@ -36,7 +35,7 @@ def run(argv):
         description="An OpenType table diff tool for fonts."
     )
     parser.add_argument(
-        "--version", action="version", version="fdiff v{}".format(__version__)
+        "--version", action="version", version=f"fdiff v{__version__}"
     )
     parser.add_argument(
         "-c",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ def test_file_exists_false():
 
 def test_get_file_modtime():
     modtime = get_file_modtime(os.path.join("tests", "testfiles", "test.txt"))
-    assert modtime.startswith("2019-09-0") is True
     regex = re.compile(r"""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[-+]\d{2}:\d{2}""")
     assert regex.fullmatch(modtime) is not None
 


### PR DESCRIPTION
- converts one string to f string
- removes UTF 8 encoding module defintitions

Closes #8