### PR TITLE
[WIP] Add remote font file diff support with asynchronous GET requests for fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       dist: xenial
       env: TOX_ENV=coverage
       install:
-        - pip install --upgrade coverage pytest
+        - pip install --upgrade coverage pytest pytest-asyncio
         - pip install .
       script:
         - make test-coverage
@@ -25,17 +25,17 @@ matrix:
         - bash <(curl -s https://codecov.io/bash)
     - python: 3.6
       env: TOX_ENV=py36
-      install: pip install --upgrade tox pytest
+      install: pip install --upgrade tox pytest pytest-asyncio
       script: tox -e $TOX_ENV
     - python: 3.7
       env: TOX_ENV=py37
-      install: pip install --upgrade tox pytest
+      install: pip install --upgrade tox pytest pytest-asyncio
       dist: xenial
       script: tox -e $TOX_ENV
     - os: osx
       language: generic
       osx_image: xcode11    # Python 3.7.4 running on macOS 10.14.4
-      install: pip3 install --upgrade tox pytest
+      install: pip3 install --upgrade tox pytest pytest-asyncio
       env: TOX_ENV=py37
       script: tox -e $TOX_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.4.0
+
+- Added support for remote font files with asynchronous I/O GET requests.  This feature supports combinations of local and remote font file comparisons.
+    - `fdiff` executable: added support for remote font files with command line URL arguments
+    - `fdiff` executable: refactored unified diff error message formatting
+    - Library: add new `fdiff.remote` module
+    - Library: add new `fdiff.aio` module
+    - Library: add new `fdiff.exceptions` module
+    - Library: refactored `fdiff.diff.unified_diff()` function to support remote files through URL
+    - Library: refactored local file path checks to support remote files via URL
+    - added new aiohttp, aiodns, aiofiles dependencies to requirements.txt
+    - added new aiohttp, aiodns, aiofiles dependencies to setup.py
+    - added pytest-asyncio dependency to setup.py [dev] install target
+    - added pytest-asyncio dependency instatllation to tox.ini, .travis.yml, .appveyor.yml configuration files
+- Py3.6+ updates: removed `# -*- coding: utf-8 -*-` header definitions (Thanks Niko!)
+- updated fontTools dependency to v4.0.1 (from v4.0.0)
+- Updated README.md documentation
+
 ## v0.3.0
 
 - Added support for head and tail diff output filter functionality

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## About
 
-`fdiff` is a Python command line comparison tool for differences in the OpenType table data between font files.  The tool provides cross-platform support on macOS, Windows, and Linux systems with a Python v3.6+ interpreter.
+`fdiff` is a Python command line comparison tool for assessment of differences in the OpenType table data between font files.  The tool provides cross-platform support on macOS, Windows, and Linux systems with a Python v3.6+ interpreter.
 
 <p align="center">
 <img src="https://raw.githubusercontent.com/source-foundry/fdiff/img/img/diff-example-crunch.png" width="500"/>
@@ -21,7 +21,7 @@
 
 ## What it does
 
-- Takes two font file path arguments for comparison
+- Takes two font file path (or URL for remote fonts) arguments for the font comparison
 - Dumps OpenType table data in the fontTools library TTX format (XML)
 - Compares the OpenType table data across the two files using the unified diff format with 3 lines of surrounding context
 
@@ -79,15 +79,33 @@ $ pip3 install --ignore-installed -r requirements.txt -e ".[dev]"
 
 ## Usage
 
+#### Local font files
+
 ```
 $ fdiff [OPTIONS] [PRE-FONT FILE PATH] [POST-FONT FILE PATH]
 ```
 
-By default, an uncolored unified diff is performed on the two files defined with the local file paths in the above command.
+#### Remote font files
+
+`fdiff` supports GET requests for publicly accessible remote font files.  Replace the file path arguments with URL:
+
+```
+$ fdiff [OPTIONS] [PRE-FONT FILE URL] [POST-FONT FILE URL]
+```
+
+`fdiff` works with any combination of local and remote font files. For example, to compare a local post font file with a remote pre font file to assess local changes against a font file that was previously pushed to a remote, use the following syntax:
+
+```
+$ fdiff [OPTIONS] [PRE-FONT FILE URL] [POST-FONT FILE FILE PATH]
+```
+
+⭐ **Tip**: Remote git repository hosting services (like Github) support access to files on different git branches by URL.  Use these repository branch URL to compare fonts across git branches in your repository.
 
 ### Options
 
 #### Color diffs
+
+Uncolored diffs are performed by default.
 
 To view a colored diff in your terminal, include either the `-c` or `--color` option in your command:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - "python -m pip install --disable-pip-version-check --user --upgrade pip setuptools virtualenv"
 
   # install the dependencies to run the tests
-  - "python -m pip install tox"
+  - "python -m pip install --upgrade tox pytest pytest-asyncio"
 
 build: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,16 @@
 codecov:
   max_report_age: off
 
-comment: off
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 2%
+        base: auto
 
 ignore:
   - "lib/fdiff/thirdparty"
+
+comment: off

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -123,10 +123,7 @@ def run(argv):
             exclude_tables=exclude_list,
         )
     except Exception as e:
-        sys.stderr.write(
-            f"[*] ERROR: During the attempt to diff the requested files the following error was encountered: "
-            f"{e}{os.linesep}"
-        )
+        sys.stderr.write(f"[*] ERROR: {e}{os.linesep}")
         sys.exit(1)
 
     # re-define the line contents of the diff iterable

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -85,12 +85,12 @@ def run(argv):
     #  File path argument validations
     # -------------------------------
 
-    if not file_exists(args.PREFILE):
+    if not args.PREFILE.startswith("http") and not file_exists(args.PREFILE):
         sys.stderr.write(
             f"[*] ERROR: The file path '{args.PREFILE}' can not be found.{os.linesep}"
         )
         sys.exit(1)
-    if not file_exists(args.POSTFILE):
+    if not args.PREFILE.startswith("http") and not file_exists(args.POSTFILE):
         sys.stderr.write(
             f"[*] ERROR: The file path '{args.POSTFILE}' can not be found.{os.linesep}"
         )

--- a/lib/fdiff/aio.py
+++ b/lib/fdiff/aio.py
@@ -1,0 +1,7 @@
+import aiofiles
+
+
+async def async_write_bin(path, binary):
+    """Asynchronous IO writes of binary data `binary` to disk on the file path `path`"""
+    async with aiofiles.open(path, "wb") as f:
+        await f.write(binary)

--- a/lib/fdiff/diff.py
+++ b/lib/fdiff/diff.py
@@ -1,8 +1,13 @@
+import asyncio
 import os
 import tempfile
 
 from fontTools.ttLib import TTFont
 
+from fdiff.remote import (
+    _get_filepath_from_url,
+    create_async_get_request_session_and_run,
+)
 from fdiff.utils import get_file_modtime
 from fdiff.thirdparty.fdifflib import unified_diff
 
@@ -25,38 +30,75 @@ def u_diff(
     :returns: Generator of ordered diff line strings that include newline line endings
     :raises: KeyError if include_tables or exclude_tables includes a mis-specified table
     that is not included in filepath_a OR filepath_b"""
-    tt_left = TTFont(filepath_a)
-    tt_right = TTFont(filepath_b)
-
-    # Validation: include_tables request should be for tables that are in one of
-    # the two fonts. This otherwise silently passes with exit status code 0 which
-    # could lead to the interpretation of no diff between two files when the table
-    # entry is incorrectly defined or is a typo.  Let's be conservative and consider
-    # this an error, force user to use explicit definitions that include tables in
-    # one of the two files, and understand that the diff request was for one or more
-    # tables that are not present.
-    if include_tables is not None:
-        for table in include_tables:
-            if table not in tt_left and table not in tt_right:
-                raise KeyError(
-                    f"'{table}' table was not identified for inclusion in either font"
-                )
-
-    # Validation: exclude_tables request should be for tables that are in one of
-    # the two fonts.  Mis-specified OT table definitions could otherwise result
-    # in the presence of a table in the diff when the request was to exclude it.
-    # For example, when an "OS/2" table request is entered as "OS2".
-    if exclude_tables is not None:
-        for table in exclude_tables:
-            if table not in tt_left and table not in tt_right:
-                raise KeyError(
-                    f"'{table}' table was not identified for exclusion in either font"
-                )
-
-    fromdate = get_file_modtime(filepath_a)
-    todate = get_file_modtime(filepath_b)
-
     with tempfile.TemporaryDirectory() as tmpdirname:
+        # define the file paths with either local file requests
+        # or pulls of remote files based on the command line request
+        urls = []
+        if filepath_a.startswith("http"):
+            urls.append(filepath_a)
+            prepath = _get_filepath_from_url(filepath_a, tmpdirname)
+            # keep URL as path name for remote file requests
+            pre_pathname = filepath_a
+        else:
+            prepath = filepath_a
+            pre_pathname = filepath_a
+
+        if filepath_b.startswith("http"):
+            urls.append(filepath_b)
+            postpath = _get_filepath_from_url(filepath_b, tmpdirname)
+            # keep URL as path name for remote file requests
+            post_pathname = filepath_b
+        else:
+            postpath = filepath_b
+            post_pathname = filepath_b
+
+        # Async IO fetch and write of any remote file requests
+        if len(urls) > 0:
+            loop = asyncio.get_event_loop()
+            tasks = loop.run_until_complete(
+                create_async_get_request_session_and_run(urls, tmpdirname)
+            )
+            for task in tasks:
+                if task.exception():
+                    # raise exception here to notify calling code that something
+                    # did not work
+                    # TODO: handle exceptions
+                    pass
+                elif task.result().http_status != 200:
+                    # TODO: handle non-200 HTTP response status codes + file write fails
+                    pass
+
+        tt_left = TTFont(prepath)
+        tt_right = TTFont(postpath)
+
+        # Validation: include_tables request should be for tables that are in one of
+        # the two fonts. This otherwise silently passes with exit status code 0 which
+        # could lead to the interpretation of no diff between two files when the table
+        # entry is incorrectly defined or is a typo.  Let's be conservative and consider
+        # this an error, force user to use explicit definitions that include tables in
+        # one of the two files, and understand that the diff request was for one or more
+        # tables that are not present.
+        if include_tables is not None:
+            for table in include_tables:
+                if table not in tt_left and table not in tt_right:
+                    raise KeyError(
+                        f"'{table}' table was not identified for inclusion in either font"
+                    )
+
+        # Validation: exclude_tables request should be for tables that are in one of
+        # the two fonts.  Mis-specified OT table definitions could otherwise result
+        # in the presence of a table in the diff when the request was to exclude it.
+        # For example, when an "OS/2" table request is entered as "OS2".
+        if exclude_tables is not None:
+            for table in exclude_tables:
+                if table not in tt_left and table not in tt_right:
+                    raise KeyError(
+                        f"'{table}' table was not identified for exclusion in either font"
+                    )
+
+        fromdate = get_file_modtime(prepath)
+        todate = get_file_modtime(postpath)
+
         tt_left.saveXML(
             os.path.join(tmpdirname, "left.ttx"),
             tables=include_tables,
@@ -76,8 +118,8 @@ def u_diff(
         return unified_diff(
             fromlines,
             tolines,
-            filepath_a,
-            filepath_b,
+            pre_pathname,
+            post_pathname,
             fromdate,
             todate,
             n=context_lines,

--- a/lib/fdiff/exceptions.py
+++ b/lib/fdiff/exceptions.py
@@ -1,0 +1,2 @@
+class AIOError(Exception):
+    pass

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -1,0 +1,51 @@
+import os.path
+import urllib.parse
+
+import aiohttp
+import asyncio
+import aiofiles
+
+
+def _get_temp_filepath_from_url(url, dirpath):
+    url_path_list = urllib.parse.urlsplit(url)
+    abs_filepath = url_path_list.path
+    basepath = os.path.split(abs_filepath)[-1]
+    return os.path.join(dirpath, basepath)
+
+
+async def async_write(path, binary):
+    async with aiofiles.open(path, "wb") as f:
+        await f.write(binary)
+
+
+async def async_fetch(session, url):
+    async with session.get(url) as response:
+        status = response.status
+        if status != 200:
+            binary = None
+        else:
+            binary = await response.read()
+        return url, status, binary
+
+
+async def async_fetch_and_write(session, url, dirpath):
+    url, status, binary = await async_fetch(session, url)
+    if status != 200:
+        filepath = None
+        return url, filepath, False
+    else:
+        filepath = _get_temp_filepath_from_url(url, dirpath)
+        await async_write(filepath, binary)
+        return url, filepath, True
+
+
+async def create_async_get_request_session_and_run(urls, dirpath):
+    async with aiohttp.ClientSession() as session:
+        tasks = []
+        for url in urls:
+            # use asyncio.ensure_future instead of .run() here to maintain
+            # Py3.6 compatibility
+            task = asyncio.ensure_future(async_fetch_and_write(session, url, dirpath))
+            tasks.append(task)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        return tasks

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -1,6 +1,8 @@
 import os.path
 import urllib.parse
 
+from collections import namedtuple
+
 import aiohttp
 import asyncio
 
@@ -25,15 +27,21 @@ async def async_fetch(session, url):
 
 
 async def async_fetch_and_write(session, url, dirpath):
+    FWResponse = namedtuple(
+        "FWRes", ["url", "filepath", "http_status", "write_success"]
+    )
     url, status, binary = await async_fetch(session, url)
     if status != 200:
         filepath = None
-        return url, filepath, False
+        write_success = False
     else:
         filepath = _get_filepath_from_url(url, dirpath)
         await async_write_bin(filepath, binary)
-        # TODO: refactor to namedtuple?
-        return url, filepath, True
+        write_success = True
+
+    return FWResponse(
+        url=url, filepath=filepath, http_status=status, write_success=write_success
+    )
 
 
 async def create_async_get_request_session_and_run(urls, dirpath):

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -3,7 +3,8 @@ import urllib.parse
 
 import aiohttp
 import asyncio
-import aiofiles
+
+from fdiff.aio import async_write_bin
 
 
 def _get_filepath_from_url(url, dirpath):
@@ -11,11 +12,6 @@ def _get_filepath_from_url(url, dirpath):
     abs_filepath = url_path_list.path
     basepath = os.path.split(abs_filepath)[-1]
     return os.path.join(dirpath, basepath)
-
-
-async def async_write(path, binary):
-    async with aiofiles.open(path, "wb") as f:
-        await f.write(binary)
 
 
 async def async_fetch(session, url):
@@ -35,7 +31,8 @@ async def async_fetch_and_write(session, url, dirpath):
         return url, filepath, False
     else:
         filepath = _get_filepath_from_url(url, dirpath)
-        await async_write(filepath, binary)
+        await async_write_bin(filepath, binary)
+        # TODO: refactor to namedtuple?
         return url, filepath, True
 
 

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -6,7 +6,7 @@ import asyncio
 import aiofiles
 
 
-def _get_temp_filepath_from_url(url, dirpath):
+def _get_filepath_from_url(url, dirpath):
     url_path_list = urllib.parse.urlsplit(url)
     abs_filepath = url_path_list.path
     basepath = os.path.split(abs_filepath)[-1]
@@ -34,7 +34,7 @@ async def async_fetch_and_write(session, url, dirpath):
         filepath = None
         return url, filepath, False
     else:
-        filepath = _get_temp_filepath_from_url(url, dirpath)
+        filepath = _get_filepath_from_url(url, dirpath)
         await async_write(filepath, binary)
         return url, filepath, True
 

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -10,6 +10,7 @@ from fdiff.aio import async_write_bin
 
 
 def _get_filepath_from_url(url, dirpath):
+    """Returns filepath from base file name in URL and directory path."""
     url_path_list = urllib.parse.urlsplit(url)
     abs_filepath = url_path_list.path
     basepath = os.path.split(abs_filepath)[-1]
@@ -17,6 +18,7 @@ def _get_filepath_from_url(url, dirpath):
 
 
 async def async_fetch(session, url):
+    """Asynchronous I/O HTTP GET request with a ClientSession instantiated from the aiohttp library."""
     async with session.get(url) as response:
         status = response.status
         if status != 200:
@@ -27,6 +29,10 @@ async def async_fetch(session, url):
 
 
 async def async_fetch_and_write(session, url, dirpath):
+    """Asynchronous I/O HTTP GET request with a ClientSession instantiated from the aiohttp library, followed
+    by an asynchronous I/O file write of the binary to disk with the aiofiles library.
+
+    :returns `FWRes` namedtuple with url, filepath, http_status, write_success fields"""
     FWResponse = namedtuple(
         "FWRes", ["url", "filepath", "http_status", "write_success"]
     )
@@ -45,6 +51,10 @@ async def async_fetch_and_write(session, url, dirpath):
 
 
 async def create_async_get_request_session_and_run(urls, dirpath):
+    """Creates an aiohttp library ClientSession and performs asynchronous GET requests +
+    binary file writes with the binary response from the GET request.
+
+    :returns list of asyncio Tasks that include `FWRes` namedtuple instances (defined in async_fetch_and_write)"""
     async with aiohttp.ClientSession() as session:
         tasks = []
         for url in urls:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fontTools == 4.0.0
+fontTools == 4.0.1
 aiohttp == 3.6.0
 aiodns == 2.0.0
 aiofiles == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 fontTools == 4.0.0
+aiohttp == 3.6.0
+aiodns == 2.0.0
+aiofiles == 0.4.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,12 @@ EMAIL = "chris@sourcefoundry.org"
 AUTHOR = "Source Foundry Authors"
 REQUIRES_PYTHON = ">=3.6.0"
 
-INSTALL_REQUIRES = ["fontTools >= 4.0.0"]
+INSTALL_REQUIRES = [
+    "fontTools >= 4.0.0",
+    "aiohttp >= 3.6.0",
+    "aiodns >= 2.0.0",
+    "aiofiles >= 0.4.0"
+]
 # Optional packages
 EXTRAS_REQUIRES = {
     # for developer installs

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
 # Optional packages
 EXTRAS_REQUIRES = {
     # for developer installs
-    "dev": ["coverage", "pytest", "tox", "flake8", "pytype"],
+    "dev": ["coverage", "pytest", "pytest-asyncio", "tox", "flake8", "pytype"],
     # for maintainer installs
     "maintain": ["wheel", "setuptools", "twine"],
 }

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+
+import pytest
+
+from fdiff.aio import async_write_bin
+
+
+@pytest.mark.asyncio
+async def test_async_write():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        test_path = os.path.join(tmpdirname, "test.bin")
+        await async_write_bin(test_path, b"test")
+        assert os.path.exists(test_path) is True
+        with open(test_path, "rb") as f:
+            res = f.read()
+            assert res == b"test"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from fdiff.diff import u_diff
+from fdiff.exceptions import AIOError
 
 ROBOTO_BEFORE_PATH = os.path.join("tests", "testfiles", "Roboto-Regular.subset1.ttf")
 ROBOTO_AFTER_PATH = os.path.join("tests", "testfiles", "Roboto-Regular.subset2.ttf")
@@ -12,6 +13,11 @@ ROBOTO_UDIFF_1CONTEXT_EXPECTED_PATH = os.path.join("tests", "testfiles", "roboto
 ROBOTO_UDIFF_HEADONLY_EXPECTED_PATH = os.path.join("tests", "testfiles", "roboto_udiff_headonly_expected.txt")
 ROBOTO_UDIFF_HEADPOSTONLY_EXPECTED_PATH = os.path.join("tests", "testfiles", "roboto_udiff_headpostonly_expected.txt")
 ROBOTO_UDIFF_EXCLUDE_HEADPOST_EXPECTED_PATH = os.path.join("tests", "testfiles", "roboto_udiff_ex_headpost_expected.txt")
+
+ROBOTO_BEFORE_URL = "https://github.com/source-foundry/fdiff/raw/master/tests/testfiles/Roboto-Regular.subset1.ttf"
+ROBOTO_AFTER_URL = "https://github.com/source-foundry/fdiff/raw/master/tests/testfiles/Roboto-Regular.subset2.ttf"
+
+URL_404 = "https://httpbin.org/status/404"
 
 # Setup: define the expected diff text for unified diff
 with open(ROBOTO_UDIFF_EXPECTED_PATH, "r") as robo_udiff:
@@ -141,3 +147,67 @@ def test_unified_diff_include_with_bad_table_definition():
 def test_unified_diff_exclude_with_bad_table_definition():
     with pytest.raises(KeyError):
         u_diff(ROBOTO_BEFORE_PATH, ROBOTO_AFTER_PATH, exclude_tables=["bogus"])
+
+
+def test_unified_diff_remote_fonts():
+    res = u_diff(ROBOTO_BEFORE_URL, ROBOTO_AFTER_URL)
+    res_string = "".join(res)
+    res_string_list = res_string.split("\n")
+    expected_string_list = ROBOTO_UDIFF_EXPECTED.split("\n")
+
+    # have to handle the tests for the top two file path lines
+    # differently than the rest of the comparisons
+    for x, line in enumerate(res_string_list):
+        # treat top two lines of the diff as comparison of first 10 chars only
+        if x == 0:
+            assert line[0:9] == "--- https"
+        elif x == 1:
+            assert line[0:9] == "+++ https"
+        else:
+            assert line == expected_string_list[x]
+
+
+def test_unified_diff_remote_and_local_fonts():
+    res = u_diff(ROBOTO_BEFORE_URL, ROBOTO_AFTER_PATH)
+    res_string = "".join(res)
+    res_string_list = res_string.split("\n")
+    expected_string_list = ROBOTO_UDIFF_EXPECTED.split("\n")
+
+    # have to handle the tests for the top two file path lines
+    # differently than the rest of the comparisons
+    for x, line in enumerate(res_string_list):
+        # treat top two lines of the diff as comparison of first 10 chars only
+        if x == 0:
+            assert line[0:9] == "--- https"
+        elif x == 1:
+            assert line[0:9] == expected_string_list[x][0:9]
+        else:
+            assert line == expected_string_list[x]
+
+
+def test_unified_diff_local_and_remote_fonts():
+    res = u_diff(ROBOTO_BEFORE_PATH, ROBOTO_AFTER_URL)
+    res_string = "".join(res)
+    res_string_list = res_string.split("\n")
+    expected_string_list = ROBOTO_UDIFF_EXPECTED.split("\n")
+
+    # have to handle the tests for the top two file path lines
+    # differently than the rest of the comparisons
+    for x, line in enumerate(res_string_list):
+        # treat top two lines of the diff as comparison of first 10 chars only
+        if x == 0:
+            assert line[0:9] == expected_string_list[x][0:9]
+        elif x == 1:
+            assert line[0:9] == "+++ https"
+        else:
+            assert line == expected_string_list[x]
+
+
+def test_unified_diff_remote_404_first_file():
+    with pytest.raises(AIOError):
+        u_diff(URL_404, ROBOTO_AFTER_URL)
+
+
+def test_unified_diff_remote_404_second_file():
+    with pytest.raises(AIOError):
+        u_diff(ROBOTO_BEFORE_URL, URL_404)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,16 @@
+from fdiff.exceptions import AIOError
+
+import pytest
+
+
+def raise_aioerror(message):
+    raise AIOError(message)
+
+
+def test_aioerror_raises():
+    with pytest.raises(AIOError) as e:
+        raise_aioerror("Test message")
+
+    assert str(e.value) == "Test message"
+
+

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+
+import pytest
+
+import aiohttp
+
+from fdiff.remote import _get_filepath_from_url, async_fetch, async_fetch_and_write, create_async_get_request_session_and_run
+
+REMOTE_FONT_1 = "https://github.com/source-foundry/fdiff/raw/master/tests/testfiles/Roboto-Regular.subset1.ttf"
+REMOTE_FONT_2 = "https://github.com/source-foundry/fdiff/raw/master/tests/testfiles/Roboto-Regular.subset2.ttf"
+
+URL_200 = "https://httpbin.org/status/200"
+URL_404 = "https://httpbin.org/status/404"
+
+
+def test_get_temp_filepath_from_url():
+    res = _get_filepath_from_url(REMOTE_FONT_1, os.path.join("test", "path"))
+    assert res == os.path.join("test", "path", "Roboto-Regular.subset1.ttf")
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_200():
+    async with aiohttp.ClientSession() as session:
+        url, status, binary = await async_fetch(session, URL_200)
+        assert url == URL_200
+        assert status == 200
+        assert binary is not None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_404():
+    async with aiohttp.ClientSession() as session:
+        url, status, binary = await async_fetch(session, URL_404)
+        assert url == URL_404
+        assert status == 404
+        assert binary is None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_and_write_200():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        async with aiohttp.ClientSession() as session:
+            fwres = await async_fetch_and_write(session, REMOTE_FONT_1, tmpdirname)
+            assert fwres.url == REMOTE_FONT_1
+            assert fwres.filepath == _get_filepath_from_url(REMOTE_FONT_1, tmpdirname)
+            assert fwres.http_status == 200
+            assert fwres.write_success is True
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_and_write_404():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        async with aiohttp.ClientSession() as session:
+            fwres = await async_fetch_and_write(session, URL_404, tmpdirname)
+            assert fwres.url == URL_404
+            assert fwres.filepath is None
+            assert fwres.http_status == 404
+            assert fwres.write_success is False
+
+
+@pytest.mark.asyncio
+async def test_create_async_get_request_session_and_run_200():
+    urls = [REMOTE_FONT_1, REMOTE_FONT_2]
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tasks = await create_async_get_request_session_and_run(urls, tmpdirname)
+        for x, task in enumerate(tasks):
+            assert task.exception() is None
+            assert task.result().url == urls[x]
+            assert task.result().http_status == 200
+            assert os.path.exists(task.result().filepath)
+            assert task.result().write_success is True
+
+
+@pytest.mark.asyncio
+async def test_create_async_get_request_session_and_run_404_single():
+    urls = [REMOTE_FONT_1, URL_404]
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tasks = await create_async_get_request_session_and_run(urls, tmpdirname)
+        for x, task in enumerate(tasks):
+            if x == 0:
+                assert task.exception() is None
+                assert task.result().url == urls[x]
+                assert task.result().http_status == 200
+                assert os.path.exists(task.result().filepath)
+                assert task.result().write_success is True
+            else:
+                assert task.exception() is None
+                assert task.result().url == urls[x]
+                assert task.result().http_status == 404
+                assert task.result().filepath is None
+                assert task.result().write_success is False
+
+
+@pytest.mark.asyncio
+async def test_create_async_get_request_session_and_run_404_both():
+    urls = [URL_404, URL_404]
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tasks = await create_async_get_request_session_and_run(urls, tmpdirname)
+        for x, task in enumerate(tasks):
+            assert task.exception() is None
+            assert task.result().url == urls[x]
+            assert task.result().http_status == 404
+            assert task.result().filepath is None
+            assert task.result().write_success is False

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,4 @@ commands =
     py.test
 deps =
     pytest
+    pytest-asyncio


### PR DESCRIPTION
Adds support for ttx XML diffs of:

- two remote font files
- combinations of a local and remote font file

Closes #2 

### TODO:

- [x] add remote font file pull exception handling in `fdiff.diff` module
- [x] add non-200 HTTP GET request response status code handling in `fdiff.diff` module
- [x] add new `fdiff.diff` module tests for remote files
- [x] add executable integration tests with new support for URL requests for remote files