### PR TITLE
Improve execution time with parallel TTFont.saveXML

### DIFF
--- a/lib/fdiff/__init__.py
+++ b/lib/fdiff/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-version = __version__ = "0.4.0"
+version = __version__ = "0.5.0.dev0"

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -144,17 +144,17 @@ def run(argv):
         iterable = diff
 
     # print unified diff results to standard output stream
-    # TODO: add support for text output to indicate that there was no diff found
-    # TODO: ( see https://stackoverflow.com/a/661967 )
-    has_output = False
+    has_diff = False
     if args.color:
         for line in iterable:
-            has_output = True
+            has_diff = True
             sys.stdout.write(color_unified_diff_line(line))
     else:
         for line in iterable:
-            has_output = True
+            has_diff = True
             sys.stdout.write(line)
 
-    if not has_output:
+    # if no difference was found, tell the user instead of
+    # simply closing with zero exit status code.
+    if not has_diff:
         print("[*] There is no difference between the files.")

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -59,6 +59,9 @@ def run(argv):
     )
     parser.add_argument("--head", type=int, help="Display first n lines of output")
     parser.add_argument("--tail", type=int, help="Display last n lines of output")
+    parser.add_argument(
+        "--nomp", action="store_true", help="Do not use multi process optimizations"
+    )
     parser.add_argument("PREFILE", help="Font file path 1")
     parser.add_argument("POSTFILE", help="Font file path 2")
 
@@ -113,6 +116,10 @@ def run(argv):
     include_list = get_tables_argument_list(args.include)
     exclude_list = get_tables_argument_list(args.exclude)
 
+    # flip logic of the command line flag for multi process
+    # optimizations for use as a u_diff function argument
+    use_mp = not args.nomp
+
     # perform the unified diff analysis
     try:
         diff = u_diff(
@@ -121,6 +128,7 @@ def run(argv):
             context_lines=args.lines,
             include_tables=include_list,
             exclude_tables=exclude_list,
+            use_multiprocess=use_mp,
         )
     except Exception as e:
         sys.stderr.write(f"[*] ERROR: {e}{os.linesep}")

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -144,8 +144,17 @@ def run(argv):
         iterable = diff
 
     # print unified diff results to standard output stream
+    # TODO: add support for text output to indicate that there was no diff found
+    # TODO: ( see https://stackoverflow.com/a/661967 )
+    has_output = False
     if args.color:
         for line in iterable:
+            has_output = True
             sys.stdout.write(color_unified_diff_line(line))
     else:
-        sys.stdout.writelines(iterable)
+        for line in iterable:
+            has_output = True
+            sys.stdout.write(line)
+
+    if not has_output:
+        print("[*] There is no difference between the files.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -92,8 +92,38 @@ def test_main_include_exclude_defined_simultaneously(capsys):
 #  Unified diff integration tests
 #
 
+def test_main_run_unified_default_local_files_no_diff(capsys):
+    """Test default behavior when there is no difference in font files under evaluation"""
+    args = [ROBOTO_BEFORE_PATH, ROBOTO_BEFORE_PATH]
+
+    run(args)
+    captured = capsys.readouterr()
+    assert captured.out == f"[*] There is no difference between the files.{os.linesep}"
+
+
 def test_main_run_unified_default_local_files(capsys):
     args = [ROBOTO_BEFORE_PATH, ROBOTO_AFTER_PATH]
+
+    run(args)
+    captured = capsys.readouterr()
+
+    res_string_list = captured.out.split("\n")
+    expected_string_list = ROBOTO_UDIFF_EXPECTED.split("\n")
+
+    # have to handle the tests for the top two file path lines
+    # differently than the rest of the comparisons because
+    # the time is defined using local platform settings
+    # which makes tests fail on different remote CI testing services
+    for x, line in enumerate(res_string_list):
+        # treat top two lines of the diff as comparison of first 10 chars only
+        if x in (0, 1):
+            assert line[0:9] == expected_string_list[x][0:9]
+        else:
+            assert line == expected_string_list[x]
+
+
+def test_main_run_unified_local_files_without_mp_optimizations(capsys):
+    args = ["--nomp", ROBOTO_BEFORE_PATH, ROBOTO_AFTER_PATH]
 
     run(args)
     captured = capsys.readouterr()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,7 +98,7 @@ def test_main_run_unified_default_local_files_no_diff(capsys):
 
     run(args)
     captured = capsys.readouterr()
-    assert captured.out == f"[*] There is no difference between the files.{os.linesep}"
+    assert captured.out.startswith("[*] There is no difference between the files.")
 
 
 def test_main_run_unified_default_local_files(capsys):


### PR DESCRIPTION
Adds a new default parallel approach to TTX XML dumps for each of the fonts with a new `--nomp` option to return to sequential execution.  Falls back to sequential execution if the platform does not have more than one CPU.  Profiling suggests that this method is near the top of the execution time list.  In my testing, this can decrease diff times by as much as ~30% on a LGC font of average size.  For larger fonts with differences, the CPython `difflib` execution time becomes a much more dominant factor in the overall processing time.  