### PR TITLE
Add type annotations and static type checks

### DIFF
--- a/.github/workflows/py-typecheck.yml
+++ b/.github/workflows/py-typecheck.yml
@@ -1,0 +1,22 @@
+name: Python Type Checks
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python testing dependencies
+        run: pip install --upgrade mypy
+      - name: Static type checks
+        run: mypy lib/fdiff

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 
 # pytype
 .pytype
+
+# VSCode
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: install
 
 black:
-	black lib/fdiff/*.py
+	black -l 90 lib/fdiff/*.py
 
 clean:
 	- rm dist/*.whl dist/*.tar.gz dist/*.zip
@@ -29,10 +29,10 @@ test-coverage:
 #	coverage html
 
 test-lint:
-	flake8 --ignore=E501,W50 lib/fdiff
+	flake8 --ignore=W50 lib/fdiff
 
 test-type-check:
-	pytype lib/fdiff
+	mypy lib/fdiff
 
 test-unit:
 	tox

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub license](https://img.shields.io/github/license/source-foundry/fdiff?color=blue)](https://github.com/source-foundry/fdiff/blob/master/LICENSE)
 ![Python CI](https://github.com/source-foundry/fdiff/workflows/Python%20CI/badge.svg)
 ![Python Lints](https://github.com/source-foundry/fdiff/workflows/Python%20Lints/badge.svg)
+![Python Type Checks](https://github.com/source-foundry/fdiff/workflows/Python%20Type%20Checks/badge.svg)
 [![codecov](https://codecov.io/gh/source-foundry/fdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/source-foundry/fdiff)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b58954eda44b4fd88ad8f4fa06e8010b)](https://www.codacy.com/app/SourceFoundry/fdiff)
 

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -3,15 +3,16 @@
 import os
 import sys
 import argparse
+from typing import Iterator, Iterable, List, Optional, Text, Tuple
 
-from fdiff import __version__
-from fdiff.color import color_unified_diff_line
-from fdiff.diff import external_diff, u_diff
-from fdiff.textiter import head, tail
-from fdiff.utils import file_exists, get_tables_argument_list
+from . import __version__
+from .color import color_unified_diff_line
+from .diff import external_diff, u_diff
+from .textiter import head, tail
+from .utils import file_exists, get_tables_argument_list
 
 
-def main():  # pragma: no cover
+def main() -> None:  # pragma: no cover
     # try/except block rationale:
     # handles "premature" socket closure exception that is
     # raised by Python when stdout is piped to tools like
@@ -27,13 +28,11 @@ def main():  # pragma: no cover
         sys.exit(0)
 
 
-def run(argv):
+def run(argv: List[Text]) -> None:
     # ------------------------------------------
     # argparse command line argument definitions
     # ------------------------------------------
-    parser = argparse.ArgumentParser(
-        description="An OpenType table diff tool for fonts."
-    )
+    parser = argparse.ArgumentParser(description="An OpenType table diff tool for fonts.")
     parser.add_argument("--version", action="version", version=f"fdiff v{__version__}")
     parser.add_argument(
         "-c",
@@ -66,7 +65,7 @@ def run(argv):
     parser.add_argument("PREFILE", help="Font file path/URL 1")
     parser.add_argument("POSTFILE", help="Font file path/URL 2")
 
-    args = parser.parse_args(argv)
+    args: argparse.Namespace = parser.parse_args(argv)
 
     # /////////////////////////////////////////////////////////
     #
@@ -110,12 +109,12 @@ def run(argv):
     # the command line arguments
     # set as a Python list if it was defined on the command line
     # or as None if it was not set on the command line
-    include_list = get_tables_argument_list(args.include)
-    exclude_list = get_tables_argument_list(args.exclude)
+    include_list: Optional[List[Text]] = get_tables_argument_list(args.include)
+    exclude_list: Optional[List[Text]] = get_tables_argument_list(args.exclude)
 
     # flip logic of the command line flag for multi process
     # optimization use
-    use_mp = not args.nomp
+    use_mp: bool = not args.nomp
 
     if args.external:
         # ------------------------------
@@ -138,7 +137,7 @@ def run(argv):
             sys.exit(1)
 
         try:
-            diff = external_diff(
+            ext_diff: Iterable[Tuple[Text, Optional[int]]] = external_diff(
                 args.external,
                 args.PREFILE,
                 args.POSTFILE,
@@ -148,7 +147,7 @@ def run(argv):
             )
 
             # write stdout from external tool
-            for line, exit_code in diff:
+            for line, exit_code in ext_diff:
                 # format with color if color flag is entered on command line
                 if args.color:
                     sys.stdout.write(color_unified_diff_line(line))
@@ -165,7 +164,7 @@ def run(argv):
         # ---------------
         # perform the unified diff analysis
         try:
-            diff = u_diff(
+            uni_diff: Iterator[Text] = u_diff(
                 args.PREFILE,
                 args.POSTFILE,
                 context_lines=args.lines,
@@ -180,11 +179,11 @@ def run(argv):
         # re-define the line contents of the diff iterable
         # if head or tail is requested
         if args.head:
-            iterable = head(diff, args.head)
+            iterable = head(uni_diff, args.head)
         elif args.tail:
-            iterable = tail(diff, args.tail)
+            iterable = tail(uni_diff, args.tail)
         else:
-            iterable = diff
+            iterable = uni_diff
 
         # print unified diff results to standard output stream
         has_diff = False

--- a/lib/fdiff/__main__.py
+++ b/lib/fdiff/__main__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import sys
-import argparse
-from typing import Iterator, Iterable, List, Optional, Text, Tuple
+from typing import Iterable, Iterator, List, Optional, Text, Tuple
 
 from . import __version__
 from .color import color_unified_diff_line

--- a/lib/fdiff/aio.py
+++ b/lib/fdiff/aio.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 
-import aiofiles
+import os
+from typing import AnyStr, Text, Union
+
+import aiofiles  # type: ignore
 
 
-async def async_write_bin(path, binary):
+async def async_write_bin(
+    path: Union[AnyStr, "os.PathLike[Text]"], binary: bytes
+) -> None:
     """Asynchronous IO writes of binary data `binary` to disk on the file path `path`"""
-    async with aiofiles.open(path, "wb") as f:
+    async with aiofiles.open(path, "wb") as f:  # type: ignore
         await f.write(binary)

--- a/lib/fdiff/color.py
+++ b/lib/fdiff/color.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
-ansicolors = {
+from typing import Dict, Text
+
+ansicolors: Dict[Text, Text] = {
     "BLACK": "\033[30m",
     "RED": "\033[31m",
     "GREEN": "\033[32m",
@@ -13,13 +15,13 @@ ansicolors = {
     "RESET": "\033[0m",
 }
 
-green_start = ansicolors["GREEN"]
-red_start = ansicolors["RED"]
-cyan_start = ansicolors["CYAN"]
-reset = ansicolors["RESET"]
+green_start: Text = ansicolors["GREEN"]
+red_start: Text = ansicolors["RED"]
+cyan_start: Text = ansicolors["CYAN"]
+reset: Text = ansicolors["RESET"]
 
 
-def color_unified_diff_line(line):
+def color_unified_diff_line(line: Text) -> Text:
     """Returns an ANSI escape code colored string with color based
     on the unified diff line type."""
     if line[0:2] == "+ ":

--- a/lib/fdiff/diff.py
+++ b/lib/fdiff/diff.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python3
 
 import asyncio
-from difflib import unified_diff
 import os
-from multiprocessing import Pool, cpu_count
 import shlex
 import subprocess
 import tempfile
-from typing import Any, Iterator, Iterable, List, Optional, Text, Tuple
+from difflib import unified_diff
+from multiprocessing import Pool, cpu_count
+from typing import Any, Iterable, Iterator, List, Optional, Text, Tuple
 
 from fontTools.ttLib import TTFont  # type: ignore
 
 from .exceptions import AIOError
-from .remote import (
-    _get_filepath_from_url,
-    create_async_get_request_session_and_run,
-)
-
+from .remote import (_get_filepath_from_url,
+                     create_async_get_request_session_and_run)
 from .utils import get_file_modtime
-
 
 #
 #

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -3,15 +3,23 @@
 import os.path
 import urllib.parse
 
-from collections import namedtuple
+# from collections import namedtuple
+from typing import Any, AnyStr, List, NamedTuple, Optional, Text, Tuple
 
-import aiohttp
+import aiohttp  # type: ignore
 import asyncio
 
-from fdiff.aio import async_write_bin
+from .aio import async_write_bin
 
 
-def _get_filepath_from_url(url, dirpath):
+class FWRes(NamedTuple):
+    url: Text
+    filepath: Optional[Text]
+    http_status: int
+    write_success: bool
+
+
+def _get_filepath_from_url(url: Text, dirpath: Text) -> Text:
     """Returns filepath from base file name in URL and directory path."""
     url_path_list = urllib.parse.urlsplit(url)
     abs_filepath = url_path_list.path
@@ -19,7 +27,7 @@ def _get_filepath_from_url(url, dirpath):
     return os.path.join(dirpath, basepath)
 
 
-async def async_fetch(session, url):
+async def async_fetch(session: Any, url: AnyStr) -> Tuple[AnyStr, Any, Any]:
     """Asynchronous I/O HTTP GET request with a ClientSession instantiated
     from the aiohttp library."""
     async with session.get(url) as response:
@@ -31,15 +39,12 @@ async def async_fetch(session, url):
         return url, status, binary
 
 
-async def async_fetch_and_write(session, url, dirpath):
+async def async_fetch_and_write(session: Any, url: Text, dirpath: Text) -> FWRes:
     """Asynchronous I/O HTTP GET request with a ClientSession instantiated
     from the aiohttp library, followed by an asynchronous I/O file write of
     the binary to disk with the aiofiles library.
 
     :returns `FWRes` namedtuple with url, filepath, http_status, write_success fields"""
-    FWResponse = namedtuple(
-        "FWRes", ["url", "filepath", "http_status", "write_success"]
-    )
     url, status, binary = await async_fetch(session, url)
     if status != 200:
         filepath = None
@@ -49,12 +54,14 @@ async def async_fetch_and_write(session, url, dirpath):
         await async_write_bin(filepath, binary)
         write_success = True
 
-    return FWResponse(
+    return FWRes(
         url=url, filepath=filepath, http_status=status, write_success=write_success
     )
 
 
-async def create_async_get_request_session_and_run(urls, dirpath):
+async def create_async_get_request_session_and_run(
+    urls: List[Text], dirpath: Text
+) -> List[Any]:
     """Creates an aiohttp library ClientSession and performs asynchronous GET requests +
     binary file writes with the binary response from the GET request.
 

--- a/lib/fdiff/remote.py
+++ b/lib/fdiff/remote.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
+import asyncio
 import os.path
 import urllib.parse
-
 # from collections import namedtuple
 from typing import Any, AnyStr, List, NamedTuple, Optional, Text, Tuple
 
 import aiohttp  # type: ignore
-import asyncio
 
 from .aio import async_write_bin
 

--- a/lib/fdiff/utils.py
+++ b/lib/fdiff/utils.py
@@ -3,14 +3,15 @@
 import os
 
 from datetime import datetime, timezone
+from typing import List, Optional, Text, Union
 
 
-def file_exists(path):
+def file_exists(path: Union[bytes, str, "os.PathLike[Text]"]) -> bool:
     """Validates file path as existing local file"""
     return os.path.isfile(path)
 
 
-def get_file_modtime(path):
+def get_file_modtime(path: Union[bytes, str, "os.PathLike[Text]"]) -> Text:
     """Returns ISO formatted file modification time in local system timezone"""
     return (
         datetime.fromtimestamp(os.stat(path).st_mtime, timezone.utc)
@@ -19,7 +20,7 @@ def get_file_modtime(path):
     )
 
 
-def get_tables_argument_list(table_string):
+def get_tables_argument_list(table_string: Optional[Text]) -> Optional[List[Text]]:
     """Converts a comma separated OpenType table string into a Python list or
     return None if the table_string was not defined (i.e., it was not included
     in an option on the command line). Tables that are composed of three
@@ -28,6 +29,5 @@ def get_tables_argument_list(table_string):
         return None
     else:
         return [
-            table + " " if len(table) == 3 else table
-            for table in table_string.split(",")
+            table + " " if len(table) == 3 else table for table in table_string.split(",")
         ]

--- a/lib/fdiff/utils.py
+++ b/lib/fdiff/utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-
 from datetime import datetime, timezone
 from typing import List, Optional, Text, Union
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
 # Optional packages
 EXTRAS_REQUIRES = {
     # for developer installs
-    "dev": ["coverage", "pytest", "pytest-asyncio", "tox", "flake8", "pytype"],
+    "dev": ["coverage", "pytest", "pytest-asyncio", "tox", "flake8", "mypy"],
     # for maintainer installs
     "maintain": ["wheel", "setuptools", "twine"],
 }


### PR DESCRIPTION
This PR adds:

- type annotations to all Python source files
- updates type check approach from pytype to mypy tool
- updates dev dependencies to include mypy, remove pytype
- refactor import statement sorting with `isort` default format

### TODO

- [x] add GH Action configuration for mypy type checks in GH Action CI (https://github.com/source-foundry/fdiff/pull/78/commits/307cba66308530996934a98878535f8a37fc4d62)

Closes #77 