### PR TITLE
Upgrade GH Actions codecov to v2 API 

### DIFF
--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -49,6 +49,6 @@ jobs:
           coverage report -m
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml


### PR DESCRIPTION
v1 is deprecated and being phased out
